### PR TITLE
Update module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/qdrant/operator-api
+module github.com/qdrant/kubernetes-api
 
 go 1.22.2
 


### PR DESCRIPTION
It has been renamed to `kubernetes-api`.