### PR TITLE
No need to restart all pods if RestartAllPodsConcurrently setting has been changed.

### DIFF
--- a/api/v1/qdrantcluster_types.go
+++ b/api/v1/qdrantcluster_types.go
@@ -57,6 +57,7 @@ func GetQdrantClusterCrdForHash(qc QdrantCluster) QdrantCluster {
 	cloned.Ingress = nil
 	cloned.Pauses = nil
 	cloned.Resources.Storage = ""
+	cloned.RestartAllPodsConcurrently = false
 	cloned.Service = nil
 	cloned.ServicePerNode = false
 	cloned.Size = 1


### PR DESCRIPTION
Because of the Hash is updated, it will still restart all pods concurrently if the pods need to be restarted and the setting is true.