### PR TITLE
Fix flipping `QdrantCluster.Spec.ServicePerNode` from `false` to `true`

### DIFF
--- a/api/v1/qdrantcluster_types.go
+++ b/api/v1/qdrantcluster_types.go
@@ -86,7 +86,7 @@ type QdrantClusterSpec struct {
 	// ServicePerNode specifies whether the cluster should start a dedicated service for each node.
 	// +kubebuilder:default=true
 	// +optional
-	ServicePerNode bool `json:"servicePerNode,omitempty"`
+	ServicePerNode bool `json:"servicePerNode"`
 	// ClusterManager specifies whether to use the cluster manager for this cluster.
 	// The Python-operator will deploy a dedicated cluster manager instance.
 	// The Go-operator will use a shared instance.


### PR DESCRIPTION
The default value for the field is `true`, and it is omitted from the serialized output if the field is set to false. Hence, it is possible to flip value from `true` to `false` in the following scenario:

* client submits to k8s API server with `ServicePerNode=false`
* client fetches the persisted instance from k8s API server, given that `false` for a boolean is considered empty, `ServicePerNode` field does not appear in the received payload.
* client updates the payload and sends it back the k8s API server. Given that `ServicePerNode` is not present in the payload, k8s API server is going to flip it to the default value, which is `true`

To correct this, `omitempty` tag is removed for `ServicePerNode` field, so that the field is always present in the serialized output.