### PR TITLE
Add `MarkedForDeletion` field to `ComponentReference`

### DIFF
--- a/api/v1/region_types.go
+++ b/api/v1/region_types.go
@@ -37,6 +37,9 @@ type ComponentReference struct {
 	Name string `json:"name"`
 	// Namespace is the namespace of component being referenced.
 	Namespace string `json:"namespace"`
+	// MarkedForDeletion specifies whether the component is marked for deletion
+	// +optional
+	MarkedForDeletion bool `json:"markedForDeletion,omitempty"`
 }
 
 type HelmRepository struct {

--- a/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantcloudregions.yaml
+++ b/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantcloudregions.yaml
@@ -65,6 +65,10 @@ spec:
                     kind:
                       description: Kind is the type of component being referenced
                       type: string
+                    markedForDeletion:
+                      description: MarkedForDeletion specifies whether the component
+                        is marked for deletion
+                      type: boolean
                     name:
                       description: Name is the name of component being referenced
                       type: string

--- a/crds/qdrant.io_qdrantcloudregions.yaml
+++ b/crds/qdrant.io_qdrantcloudregions.yaml
@@ -64,6 +64,10 @@ spec:
                     kind:
                       description: Kind is the type of component being referenced
                       type: string
+                    markedForDeletion:
+                      description: MarkedForDeletion specifies whether the component
+                        is marked for deletion
+                      type: boolean
                     name:
                       description: Name is the name of component being referenced
                       type: string

--- a/docs/api.md
+++ b/docs/api.md
@@ -69,6 +69,7 @@ _Appears in:_
 | `kind` _string_ | Kind is the type of component being referenced |  |  |
 | `name` _string_ | Name is the name of component being referenced |  |  |
 | `namespace` _string_ | Namespace is the namespace of component being referenced. |  |  |
+| `markedForDeletion` _boolean_ | MarkedForDeletion specifies whether the component is marked for deletion |  |  |
 
 
 #### ComponentStatus


### PR DESCRIPTION
This PR adds `MarkedForDeletion` filed to `ComponentReference` so that we can omit those components that are marked for deletion during region phase calculation.