### PR TITLE
make Qdrant Entity selectable by .spec.entityType

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
 GCI ?= $(LOCALBIN)/gci
 
-CONTROLLER_TOOLS_VERSION ?= v0.16.1
+CONTROLLER_TOOLS_VERSION ?= v0.16.5
 CRD_REF_DOCS_VERSION ?= v0.0.12
 CHART_DIR ?= charts/qdrant-kubernetes-api
 CRDS_DIR ?= crds

--- a/api/v1/qdrantentity_types.go
+++ b/api/v1/qdrantentity_types.go
@@ -119,6 +119,7 @@ func (r *QdrantEntityStatusResult) SetPayloadFromGRPC(payload *structpb.Struct) 
 // +kubebuilder:resource:path=qdrantentities,singular=qdrantentity,shortName=qe
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:selectablefield:JSONPath=`.spec.entityType`
 
 // QdrantEntity is the Schema for the qdrantentities API
 type QdrantEntity struct {

--- a/charts/qdrant-kubernetes-api/templates/management-crds/qdrant.io_qdrantreleases.yaml
+++ b/charts/qdrant-kubernetes-api/templates/management-crds/qdrant.io_qdrantreleases.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: qdrantreleases.qdrant.io
 spec:
   group: qdrant.io

--- a/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantcloudregions.yaml
+++ b/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantcloudregions.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: qdrantcloudregions.qdrant.io
 spec:
   group: qdrant.io

--- a/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantclusterrestores.yaml
+++ b/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantclusterrestores.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: qdrantclusterrestores.qdrant.io
 spec:
   group: qdrant.io

--- a/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantclusters.yaml
+++ b/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantclusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: qdrantclusters.qdrant.io
 spec:
   group: qdrant.io

--- a/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantclusterscheduledsnapshots.yaml
+++ b/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantclusterscheduledsnapshots.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: qdrantclusterscheduledsnapshots.qdrant.io
 spec:
   group: qdrant.io

--- a/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantclustersnapshots.yaml
+++ b/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantclustersnapshots.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: qdrantclustersnapshots.qdrant.io
 spec:
   group: qdrant.io

--- a/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantentities.yaml
+++ b/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantentities.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: qdrantentities.qdrant.io
 spec:
   group: qdrant.io
@@ -107,6 +107,8 @@ spec:
             type: object
             x-kubernetes-preserve-unknown-fields: true
         type: object
+    selectableFields:
+    - jsonPath: .spec.entityType
     served: true
     storage: true
     subresources:

--- a/crds/qdrant.io_qdrantcloudregions.yaml
+++ b/crds/qdrant.io_qdrantcloudregions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: qdrantcloudregions.qdrant.io
 spec:
   group: qdrant.io

--- a/crds/qdrant.io_qdrantclusterrestores.yaml
+++ b/crds/qdrant.io_qdrantclusterrestores.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: qdrantclusterrestores.qdrant.io
 spec:
   group: qdrant.io

--- a/crds/qdrant.io_qdrantclusters.yaml
+++ b/crds/qdrant.io_qdrantclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: qdrantclusters.qdrant.io
 spec:
   group: qdrant.io

--- a/crds/qdrant.io_qdrantclusterscheduledsnapshots.yaml
+++ b/crds/qdrant.io_qdrantclusterscheduledsnapshots.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: qdrantclusterscheduledsnapshots.qdrant.io
 spec:
   group: qdrant.io

--- a/crds/qdrant.io_qdrantclustersnapshots.yaml
+++ b/crds/qdrant.io_qdrantclustersnapshots.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: qdrantclustersnapshots.qdrant.io
 spec:
   group: qdrant.io

--- a/crds/qdrant.io_qdrantentities.yaml
+++ b/crds/qdrant.io_qdrantentities.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: qdrantentities.qdrant.io
 spec:
   group: qdrant.io
@@ -106,6 +106,8 @@ spec:
             type: object
             x-kubernetes-preserve-unknown-fields: true
         type: object
+    selectableFields:
+    - jsonPath: .spec.entityType
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
`// +kubebuilder:selectablefield:JSONPath=".spec.entityType"` is not supported by `controller-tools` = `v0.16.1` so had to bump it to `v0.16.5`