### PR TITLE
Upate HelmRepository to v1 and HelmRelease to v2

### DIFF
--- a/api/v1/region_types.go
+++ b/api/v1/region_types.go
@@ -1,8 +1,8 @@
 package v1
 
 import (
-	helmapi "github.com/fluxcd/helm-controller/api/v2"
-	srcapi "github.com/fluxcd/source-controller/api/v1"
+	helmapiv2 "github.com/fluxcd/helm-controller/api/v2"
+	srcapiv1 "github.com/fluxcd/source-controller/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -49,7 +49,7 @@ type HelmRepository struct {
 	MarkedForDeletionAt *string `json:"markedForDeletionAt,omitempty"`
 	// Object specifies the helm repository object
 	// +kubebuilder:validation:EmbeddedResource
-	Object *srcapi.HelmRepository `json:"object,omitempty"`
+	Object *srcapiv1.HelmRepository `json:"object,omitempty"`
 }
 
 type HelmRelease struct {
@@ -58,7 +58,7 @@ type HelmRelease struct {
 	MarkedForDeletionAt *string `json:"markedForDeletionAt,omitempty"`
 	// Object specifies the helm release object
 	// +kubebuilder:validation:EmbeddedResource
-	Object *helmapi.HelmRelease `json:"object,omitempty"`
+	Object *helmapiv2.HelmRelease `json:"object,omitempty"`
 }
 
 type RegionPhase string

--- a/api/v1/region_types.go
+++ b/api/v1/region_types.go
@@ -1,8 +1,8 @@
 package v1
 
 import (
-	helmapi "github.com/fluxcd/helm-controller/api/v2beta2"
-	srcapi "github.com/fluxcd/source-controller/api/v1beta2"
+	helmapi "github.com/fluxcd/helm-controller/api/v2"
+	srcapi "github.com/fluxcd/source-controller/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -5,8 +5,8 @@
 package v1
 
 import (
-	"github.com/fluxcd/helm-controller/api/v2beta2"
-	"github.com/fluxcd/source-controller/api/v1beta2"
+	"github.com/fluxcd/helm-controller/api/v2"
+	apiv1 "github.com/fluxcd/source-controller/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,7 +78,7 @@ func (in *HelmRelease) DeepCopyInto(out *HelmRelease) {
 	}
 	if in.Object != nil {
 		in, out := &in.Object, &out.Object
-		*out = new(v2beta2.HelmRelease)
+		*out = new(v2.HelmRelease)
 		(*in).DeepCopyInto(*out)
 	}
 }
@@ -103,7 +103,7 @@ func (in *HelmRepository) DeepCopyInto(out *HelmRepository) {
 	}
 	if in.Object != nil {
 		in, out := &in.Object, &out.Object
-		*out = new(v1beta2.HelmRepository)
+		*out = new(apiv1.HelmRepository)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantcloudregions.yaml
+++ b/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantcloudregions.yaml
@@ -118,7 +118,7 @@ spec:
                           properties:
                             chart:
                               description: |-
-                                Chart defines the template of the v1beta2.HelmChart that should be created
+                                Chart defines the template of the v1.HelmChart that should be created
                                 for this HelmRelease.
                               properties:
                                 metadata:
@@ -144,7 +144,7 @@ spec:
                                       type: object
                                   type: object
                                 spec:
-                                  description: Spec holds the template for the v1beta2.HelmChartSpec
+                                  description: Spec holds the template for the v1.HelmChartSpec
                                     for this HelmRelease.
                                   properties:
                                     chart:
@@ -203,13 +203,6 @@ spec:
                                       - kind
                                       - name
                                       type: object
-                                    valuesFile:
-                                      description: |-
-                                        Alternative values file to use as the default chart values, expected to
-                                        be a relative path in the SourceRef. Deprecated in favor of ValuesFiles,
-                                        for backwards compatibility the file defined here is merged before the
-                                        ValuesFiles items. Ignored when omitted.
-                                      type: string
                                     valuesFiles:
                                       description: |-
                                         Alternative list of values files to use as the chart values (values.yaml
@@ -253,7 +246,7 @@ spec:
                                     version:
                                       default: '*'
                                       description: |-
-                                        Version semver expression, ignored for charts from v1beta2.GitRepository and
+                                        Version semver expression, ignored for charts from v1.GitRepository and
                                         v1beta2.Bucket sources. Defaults to latest when omitted.
                                       type: string
                                   required:
@@ -267,9 +260,6 @@ spec:
                               description: |-
                                 ChartRef holds a reference to a source controller resource containing the
                                 Helm chart artifact.
-
-                                Note: this field is provisional to the v2 API, and not actively used
-                                by v2beta2 HelmReleases.
                               properties:
                                 apiVersion:
                                   description: APIVersion of the referent.
@@ -441,6 +431,16 @@ spec:
                                   description: |-
                                     DisableOpenAPIValidation prevents the Helm install action from validating
                                     rendered templates against the Kubernetes OpenAPI Schema.
+                                  type: boolean
+                                disableSchemaValidation:
+                                  description: |-
+                                    DisableSchemaValidation prevents the Helm install action from validating
+                                    the values against the JSON Schema.
+                                  type: boolean
+                                disableTakeOwnership:
+                                  description: |-
+                                    DisableTakeOwnership disables taking ownership of existing resources
+                                    during the Helm install action. Defaults to false.
                                   type: boolean
                                 disableWait:
                                   description: |-
@@ -659,114 +659,6 @@ spec:
                                           - patch
                                           type: object
                                         type: array
-                                      patchesJson6902:
-                                        description: |-
-                                          JSON 6902 patches, defined as inline YAML objects.
-                                          Deprecated: use Patches instead.
-                                        items:
-                                          description: JSON6902Patch contains a JSON6902
-                                            patch and the target the patch should
-                                            be applied to.
-                                          properties:
-                                            patch:
-                                              description: Patch contains the JSON6902
-                                                patch document with an array of operation
-                                                objects.
-                                              items:
-                                                description: |-
-                                                  JSON6902 is a JSON6902 operation object.
-                                                  https://datatracker.ietf.org/doc/html/rfc6902#section-4
-                                                properties:
-                                                  from:
-                                                    description: |-
-                                                      From contains a JSON-pointer value that references a location within the target document where the operation is
-                                                      performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
-                                                    type: string
-                                                  op:
-                                                    description: |-
-                                                      Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or
-                                                      "test".
-                                                      https://datatracker.ietf.org/doc/html/rfc6902#section-4
-                                                    enum:
-                                                    - test
-                                                    - remove
-                                                    - add
-                                                    - replace
-                                                    - move
-                                                    - copy
-                                                    type: string
-                                                  path:
-                                                    description: |-
-                                                      Path contains the JSON-pointer value that references a location within the target document where the operation
-                                                      is performed. The meaning of the value depends on the value of Op.
-                                                    type: string
-                                                  value:
-                                                    description: |-
-                                                      Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into
-                                                      account by all operations.
-                                                    x-kubernetes-preserve-unknown-fields: true
-                                                required:
-                                                - op
-                                                - path
-                                                type: object
-                                              type: array
-                                            target:
-                                              description: Target points to the resources
-                                                that the patch document should be
-                                                applied to.
-                                              properties:
-                                                annotationSelector:
-                                                  description: |-
-                                                    AnnotationSelector is a string that follows the label selection expression
-                                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                                    It matches with the resource annotations.
-                                                  type: string
-                                                group:
-                                                  description: |-
-                                                    Group is the API group to select resources from.
-                                                    Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                                    https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                                  type: string
-                                                kind:
-                                                  description: |-
-                                                    Kind of the API Group to select resources from.
-                                                    Together with Group and Version it is capable of unambiguously
-                                                    identifying and/or selecting resources.
-                                                    https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                                  type: string
-                                                labelSelector:
-                                                  description: |-
-                                                    LabelSelector is a string that follows the label selection expression
-                                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                                    It matches with the resource labels.
-                                                  type: string
-                                                name:
-                                                  description: Name to match resources
-                                                    with.
-                                                  type: string
-                                                namespace:
-                                                  description: Namespace to select
-                                                    resources from.
-                                                  type: string
-                                                version:
-                                                  description: |-
-                                                    Version of the API Group to select resources from.
-                                                    Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                                    https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                                  type: string
-                                              type: object
-                                          required:
-                                          - patch
-                                          - target
-                                          type: object
-                                        type: array
-                                      patchesStrategicMerge:
-                                        description: |-
-                                          Strategic merge patches, defined as inline YAML objects.
-                                          Deprecated: use Patches instead.
-                                        items:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                        type: array
                                     type: object
                                 type: object
                               type: array
@@ -965,6 +857,16 @@ spec:
                                   description: |-
                                     DisableOpenAPIValidation prevents the Helm upgrade action from validating
                                     rendered templates against the Kubernetes OpenAPI Schema.
+                                  type: boolean
+                                disableSchemaValidation:
+                                  description: |-
+                                    DisableSchemaValidation prevents the Helm upgrade action from validating
+                                    the values against the JSON Schema.
+                                  type: boolean
+                                disableTakeOwnership:
+                                  description: |-
+                                    DisableTakeOwnership disables taking ownership of existing resources
+                                    during the Helm upgrade action. Defaults to false.
                                   type: boolean
                                 disableWait:
                                   description: |-
@@ -1276,12 +1178,6 @@ spec:
                                 state. It is reset after a successful reconciliation.
                               format: int64
                               type: integer
-                            lastAppliedRevision:
-                              description: |-
-                                LastAppliedRevision is the revision of the last successfully applied
-                                source.
-                                Deprecated: the revision can now be found in the History.
-                              type: string
                             lastAttemptedConfigDigest:
                               description: |-
                                 LastAttemptedConfigDigest is the digest for the config (better known as

--- a/crds/qdrant.io_qdrantcloudregions.yaml
+++ b/crds/qdrant.io_qdrantcloudregions.yaml
@@ -117,7 +117,7 @@ spec:
                           properties:
                             chart:
                               description: |-
-                                Chart defines the template of the v1beta2.HelmChart that should be created
+                                Chart defines the template of the v1.HelmChart that should be created
                                 for this HelmRelease.
                               properties:
                                 metadata:
@@ -143,7 +143,7 @@ spec:
                                       type: object
                                   type: object
                                 spec:
-                                  description: Spec holds the template for the v1beta2.HelmChartSpec
+                                  description: Spec holds the template for the v1.HelmChartSpec
                                     for this HelmRelease.
                                   properties:
                                     chart:
@@ -202,13 +202,6 @@ spec:
                                       - kind
                                       - name
                                       type: object
-                                    valuesFile:
-                                      description: |-
-                                        Alternative values file to use as the default chart values, expected to
-                                        be a relative path in the SourceRef. Deprecated in favor of ValuesFiles,
-                                        for backwards compatibility the file defined here is merged before the
-                                        ValuesFiles items. Ignored when omitted.
-                                      type: string
                                     valuesFiles:
                                       description: |-
                                         Alternative list of values files to use as the chart values (values.yaml
@@ -252,7 +245,7 @@ spec:
                                     version:
                                       default: '*'
                                       description: |-
-                                        Version semver expression, ignored for charts from v1beta2.GitRepository and
+                                        Version semver expression, ignored for charts from v1.GitRepository and
                                         v1beta2.Bucket sources. Defaults to latest when omitted.
                                       type: string
                                   required:
@@ -266,9 +259,6 @@ spec:
                               description: |-
                                 ChartRef holds a reference to a source controller resource containing the
                                 Helm chart artifact.
-
-                                Note: this field is provisional to the v2 API, and not actively used
-                                by v2beta2 HelmReleases.
                               properties:
                                 apiVersion:
                                   description: APIVersion of the referent.
@@ -440,6 +430,16 @@ spec:
                                   description: |-
                                     DisableOpenAPIValidation prevents the Helm install action from validating
                                     rendered templates against the Kubernetes OpenAPI Schema.
+                                  type: boolean
+                                disableSchemaValidation:
+                                  description: |-
+                                    DisableSchemaValidation prevents the Helm install action from validating
+                                    the values against the JSON Schema.
+                                  type: boolean
+                                disableTakeOwnership:
+                                  description: |-
+                                    DisableTakeOwnership disables taking ownership of existing resources
+                                    during the Helm install action. Defaults to false.
                                   type: boolean
                                 disableWait:
                                   description: |-
@@ -658,114 +658,6 @@ spec:
                                           - patch
                                           type: object
                                         type: array
-                                      patchesJson6902:
-                                        description: |-
-                                          JSON 6902 patches, defined as inline YAML objects.
-                                          Deprecated: use Patches instead.
-                                        items:
-                                          description: JSON6902Patch contains a JSON6902
-                                            patch and the target the patch should
-                                            be applied to.
-                                          properties:
-                                            patch:
-                                              description: Patch contains the JSON6902
-                                                patch document with an array of operation
-                                                objects.
-                                              items:
-                                                description: |-
-                                                  JSON6902 is a JSON6902 operation object.
-                                                  https://datatracker.ietf.org/doc/html/rfc6902#section-4
-                                                properties:
-                                                  from:
-                                                    description: |-
-                                                      From contains a JSON-pointer value that references a location within the target document where the operation is
-                                                      performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
-                                                    type: string
-                                                  op:
-                                                    description: |-
-                                                      Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or
-                                                      "test".
-                                                      https://datatracker.ietf.org/doc/html/rfc6902#section-4
-                                                    enum:
-                                                    - test
-                                                    - remove
-                                                    - add
-                                                    - replace
-                                                    - move
-                                                    - copy
-                                                    type: string
-                                                  path:
-                                                    description: |-
-                                                      Path contains the JSON-pointer value that references a location within the target document where the operation
-                                                      is performed. The meaning of the value depends on the value of Op.
-                                                    type: string
-                                                  value:
-                                                    description: |-
-                                                      Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into
-                                                      account by all operations.
-                                                    x-kubernetes-preserve-unknown-fields: true
-                                                required:
-                                                - op
-                                                - path
-                                                type: object
-                                              type: array
-                                            target:
-                                              description: Target points to the resources
-                                                that the patch document should be
-                                                applied to.
-                                              properties:
-                                                annotationSelector:
-                                                  description: |-
-                                                    AnnotationSelector is a string that follows the label selection expression
-                                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                                    It matches with the resource annotations.
-                                                  type: string
-                                                group:
-                                                  description: |-
-                                                    Group is the API group to select resources from.
-                                                    Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                                    https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                                  type: string
-                                                kind:
-                                                  description: |-
-                                                    Kind of the API Group to select resources from.
-                                                    Together with Group and Version it is capable of unambiguously
-                                                    identifying and/or selecting resources.
-                                                    https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                                  type: string
-                                                labelSelector:
-                                                  description: |-
-                                                    LabelSelector is a string that follows the label selection expression
-                                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                                    It matches with the resource labels.
-                                                  type: string
-                                                name:
-                                                  description: Name to match resources
-                                                    with.
-                                                  type: string
-                                                namespace:
-                                                  description: Namespace to select
-                                                    resources from.
-                                                  type: string
-                                                version:
-                                                  description: |-
-                                                    Version of the API Group to select resources from.
-                                                    Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                                    https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                                  type: string
-                                              type: object
-                                          required:
-                                          - patch
-                                          - target
-                                          type: object
-                                        type: array
-                                      patchesStrategicMerge:
-                                        description: |-
-                                          Strategic merge patches, defined as inline YAML objects.
-                                          Deprecated: use Patches instead.
-                                        items:
-                                          x-kubernetes-preserve-unknown-fields: true
-                                        type: array
                                     type: object
                                 type: object
                               type: array
@@ -964,6 +856,16 @@ spec:
                                   description: |-
                                     DisableOpenAPIValidation prevents the Helm upgrade action from validating
                                     rendered templates against the Kubernetes OpenAPI Schema.
+                                  type: boolean
+                                disableSchemaValidation:
+                                  description: |-
+                                    DisableSchemaValidation prevents the Helm upgrade action from validating
+                                    the values against the JSON Schema.
+                                  type: boolean
+                                disableTakeOwnership:
+                                  description: |-
+                                    DisableTakeOwnership disables taking ownership of existing resources
+                                    during the Helm upgrade action. Defaults to false.
                                   type: boolean
                                 disableWait:
                                   description: |-
@@ -1275,12 +1177,6 @@ spec:
                                 state. It is reset after a successful reconciliation.
                               format: int64
                               type: integer
-                            lastAppliedRevision:
-                              description: |-
-                                LastAppliedRevision is the revision of the last successfully applied
-                                source.
-                                Deprecated: the revision can now be found in the History.
-                              type: string
                             lastAttemptedConfigDigest:
                               description: |-
                                 LastAttemptedConfigDigest is the digest for the config (better known as


### PR DESCRIPTION
This PR updates HelmRepository version from `v1beta1` to `v1` and HelmRelease version from `v2beta2` to `v2`.

Ticket: https://github.com/qdrant/cloud-pm/issues/2923