### PR TITLE
fix/bashofmann/enforce label action

### DIFF
--- a/.github/workflows/label-enforcer.yaml
+++ b/.github/workflows/label-enforcer.yaml
@@ -12,4 +12,4 @@ jobs:
     steps:
     - uses: TimonVS/pr-labeler-action@v5
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{ secrets.TOKEN }}


### PR DESCRIPTION
- **Fix security warning that Workflow does not contain permissions (#91)**
- **Support additional GPU config values (#90)**
- **Added support for resource QdrantEntity (#92)**
- **add optional clusterID to QdrantEntity (#96)**
- **Bump golang.org/x/net from 0.34.0 to 0.36.0 (#95)**
- **Bump sigs.k8s.io/controller-runtime from 0.20.2 to 0.20.3 (#94)**
- **make Qdrant Entity selectable by .spec.entityType (#97)**
- **Update golang to 1.24 and update dependencies (#93)**
- **Add kubeconform as a Github action step (#98)**
- **add lastUpdatedAt to Entity Status to track changes (#99)**
- **add microsec precision for Entity timestamps (#105)**
- **switch to observedGeneration to track Entity Status updates (#106)**
- **Bump github.com/onsi/gomega from 1.36.2 to 1.36.3 (#103)**
- **Bump google.golang.org/protobuf from 1.36.5 to 1.36.6 (#101)**
- **Bump sigs.k8s.io/controller-runtime from 0.20.3 to 0.20.4 (#100)**
- **Bump golangci/golangci-lint-action from 6 to 7 (#104)**
- **Bump github.com/onsi/ginkgo/v2 from 2.23.3 to 2.23.4 (#108)**
- **Add rebalanceStrategy in QdrantCluster spec (#109)**
- **Bump github.com/onsi/gomega from 1.36.3 to 1.37.0 (#107)**
- **Fix serialization of StoragePerformanceConfig (#110)**
- **Fixed typo (#112)**
- **Fix typo in traefik entryPoints json field (#114)**
- **Bump golang.org/x/net from 0.37.0 to 0.38.0 (#111)**
- **Add note on how kubernetes-api is deployed (#113)**
- **Remove GetQdrantClusterCrdForHash helper (#116)**
- **Upate HelmRepository to v1 and HelmRelease to v2 (#115)**
- **Fix permissions in enforceLabel action job**
