### PR TITLE
Re-run make gen

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -39,23 +39,6 @@ _Underlying type:_ _string_
 _Appears in:_
 - [QdrantClusterStatus](#qdrantclusterstatus)
 
-| Field | Description |
-| --- | --- |
-| `Creating` |  |
-| `FailedToCreate` |  |
-| `Updating` |  |
-| `FailedToUpdate` |  |
-| `Scaling` |  |
-| `Upgrading` |  |
-| `Suspending` |  |
-| `Suspended` |  |
-| `FailedToSuspend` |  |
-| `Resuming` |  |
-| `FailedToResume` |  |
-| `Healthy` |  |
-| `NotReady` |  |
-| `RecoveryMode` |  |
-| `ManualMaintenance` |  |
 
 
 #### ComponentPhase
@@ -69,12 +52,6 @@ _Underlying type:_ _string_
 _Appears in:_
 - [ComponentStatus](#componentstatus)
 
-| Field | Description |
-| --- | --- |
-| `Ready` |  |
-| `NotReady` |  |
-| `Unknown` |  |
-| `NotFound` |  |
 
 
 #### ComponentReference
@@ -128,14 +105,6 @@ _Underlying type:_ _string_
 _Appears in:_
 - [QdrantEntityStatus](#qdrantentitystatus)
 
-| Field | Description |
-| --- | --- |
-| `Creating` |  |
-| `Ready` |  |
-| `Updating` |  |
-| `Failing` |  |
-| `Deleting` |  |
-| `Deleted` |  |
 
 
 #### EntityResult
@@ -149,11 +118,6 @@ EntityResult is the last result from the invocation to a manager
 _Appears in:_
 - [QdrantEntityStatusResult](#qdrantentitystatusresult)
 
-| Field | Description |
-| --- | --- |
-| `Ok` |  |
-| `Pending` |  |
-| `Error` |  |
 
 
 #### GPU
@@ -190,10 +154,6 @@ _Validation:_
 _Appears in:_
 - [GPU](#gpu)
 
-| Field | Description |
-| --- | --- |
-| `nvidia` |  |
-| `amd` |  |
 
 
 #### HelmRelease
@@ -210,7 +170,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `markedForDeletionAt` _string_ | MarkedForDeletionAt specifies the time when the helm release was marked for deletion |  |  |
-| `object` _[HelmRelease](#helmrelease)_ | Object specifies the helm release object |  | EmbeddedResource: \{\} <br /> |
+| `object` _[HelmRelease](#helmrelease)_ | Object specifies the helm release object |  | EmbeddedResource: {} <br /> |
 
 
 #### HelmRepository
@@ -227,7 +187,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `markedForDeletionAt` _string_ | MarkedForDeletionAt specifies the time when the helm repository was marked for deletion |  |  |
-| `object` _[HelmRepository](#helmrepository)_ | Object specifies the helm repository object |  | EmbeddedResource: \{\} <br /> |
+| `object` _[HelmRepository](#helmrepository)_ | Object specifies the helm repository object |  | EmbeddedResource: {} <br /> |
 
 
 #### InferenceConfig
@@ -280,22 +240,6 @@ _Underlying type:_ _string_
 _Appears in:_
 - [QdrantCloudRegionStatus](#qdrantcloudregionstatus)
 
-| Field | Description |
-| --- | --- |
-| `unknown` |  |
-| `aws` |  |
-| `gcp` |  |
-| `azure` |  |
-| `do` |  |
-| `scaleway` |  |
-| `openshift` |  |
-| `linode` |  |
-| `civo` |  |
-| `oci` |  |
-| `ovhcloud` |  |
-| `stackit` |  |
-| `vultr` |  |
-| `k3s` |  |
 
 
 #### KubernetesPod
@@ -361,10 +305,6 @@ _Underlying type:_ _string_
 _Appears in:_
 - [Monitoring](#monitoring)
 
-| Field | Description |
-| --- | --- |
-| `kubelet` |  |
-| `api` |  |
 
 
 #### Monitoring
@@ -682,7 +622,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `cluster-id` _string_ | Id specifies the unique identifier of the cluster |  |  |
 | `scheduleShortId` _string_ | Specifies short Id which identifies a schedule |  | MaxLength: 8 <br /> |
-| `schedule` _string_ | Cron expression for frequency of creating snapshots, see https://en.wikipedia.org/wiki/Cron.<br />The schedule is specified in UTC. |  | Pattern: `^(@(annually\|yearly\|monthly\|weekly\|daily\|hourly\|reboot))\|(@every (\d+(ns\|us\|µs\|ms\|s\|m\|h))+)\|((((\d+,)+\d+\|([\d\*]+(\/\|-)\d+)\|\d+\|\*) ?)\{5,7\})$` <br /> |
+| `schedule` _string_ | Cron expression for frequency of creating snapshots, see https://en.wikipedia.org/wiki/Cron.<br />The schedule is specified in UTC. |  | Pattern: `^(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)|((((\d+,)+\d+|([\d\*]+(\/|-)\d+)|\d+|\*) ?){5,7})$` <br /> |
 | `retention` _string_ | Retention of schedule in hours |  | Pattern: `^[0-9]+h$` <br /> |
 
 
@@ -736,12 +676,6 @@ _Underlying type:_ _string_
 _Appears in:_
 - [QdrantClusterSnapshotStatus](#qdrantclustersnapshotstatus)
 
-| Field | Description |
-| --- | --- |
-| `Running` |  |
-| `Skipped` |  |
-| `Failed` |  |
-| `Succeeded` |  |
 
 
 #### QdrantClusterSnapshotSpec
@@ -954,7 +888,7 @@ _Appears in:_
 | `createdAt` _[MicroTime](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#microtime-v1-meta)_ | Timestamp when the entity was created. |  |  |
 | `lastUpdatedAt` _[MicroTime](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#microtime-v1-meta)_ | Timestamp when the entity was last updated. |  |  |
 | `deletedAt` _[MicroTime](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#microtime-v1-meta)_ | Timestamp when the entity was deleted (or is started to be deleting).<br />If not set the entity is not deleted |  |  |
-| `payload` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#json-v1-apiextensions-k8s-io)_ | Generic payload for this entity |  |  |
+| `payload` _[JSON](#json)_ | Generic payload for this entity |  |  |
 
 
 
@@ -974,7 +908,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `result` _[EntityResult](#entityresult)_ | The result of last reconcile of the entity |  | Enum: [Ok Pending Error] <br /> |
 | `reason` _string_ | The reason of the result (e.g. in case of an error) |  |  |
-| `payload` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#json-v1-apiextensions-k8s-io)_ | The optional payload of the status. |  |  |
+| `payload` _[JSON](#json)_ | The optional payload of the status. |  |  |
 
 
 #### QdrantImage
@@ -1103,11 +1037,6 @@ _Validation:_
 _Appears in:_
 - [QdrantClusterSpec](#qdrantclusterspec)
 
-| Field | Description |
-| --- | --- |
-| `by_count` |  |
-| `by_size` |  |
-| `by_count_and_size` |  |
 
 
 #### RegionCapabilities
@@ -1138,11 +1067,6 @@ _Underlying type:_ _string_
 _Appears in:_
 - [QdrantCloudRegionStatus](#qdrantcloudregionstatus)
 
-| Field | Description |
-| --- | --- |
-| `Ready` |  |
-| `NotReady` |  |
-| `FailedToSync` |  |
 
 
 #### ResourceRequests
@@ -1209,12 +1133,6 @@ _Underlying type:_ _string_
 _Appears in:_
 - [QdrantClusterRestoreStatus](#qdrantclusterrestorestatus)
 
-| Field | Description |
-| --- | --- |
-| `Running` |  |
-| `Skipped` |  |
-| `Failed` |  |
-| `Succeeded` |  |
 
 
 #### RestoreSource
@@ -1245,10 +1163,6 @@ _Underlying type:_ _string_
 _Appears in:_
 - [QdrantClusterScheduledSnapshotStatus](#qdrantclusterscheduledsnapshotstatus)
 
-| Field | Description |
-| --- | --- |
-| `Active` |  |
-| `Disabled` |  |
 
 
 #### StorageClass


### PR DESCRIPTION
- **Fix security warning that Workflow does not contain permissions (#91)**
- **Support additional GPU config values (#90)**
- **Added support for resource QdrantEntity (#92)**
- **add optional clusterID to QdrantEntity (#96)**
- **Bump golang.org/x/net from 0.34.0 to 0.36.0 (#95)**
- **Bump sigs.k8s.io/controller-runtime from 0.20.2 to 0.20.3 (#94)**
- **make Qdrant Entity selectable by .spec.entityType (#97)**
- **Update golang to 1.24 and update dependencies (#93)**
- **Add kubeconform as a Github action step (#98)**
- **add lastUpdatedAt to Entity Status to track changes (#99)**
- **add microsec precision for Entity timestamps (#105)**
- **switch to observedGeneration to track Entity Status updates (#106)**
- **Bump github.com/onsi/gomega from 1.36.2 to 1.36.3 (#103)**
- **Bump google.golang.org/protobuf from 1.36.5 to 1.36.6 (#101)**
- **Bump sigs.k8s.io/controller-runtime from 0.20.3 to 0.20.4 (#100)**
- **Bump golangci/golangci-lint-action from 6 to 7 (#104)**
- **Bump github.com/onsi/ginkgo/v2 from 2.23.3 to 2.23.4 (#108)**
- **Add rebalanceStrategy in QdrantCluster spec (#109)**
- **Bump github.com/onsi/gomega from 1.36.3 to 1.37.0 (#107)**
- **Fix serialization of StoragePerformanceConfig (#110)**
- **Fixed typo (#112)**
- **Fix typo in traefik entryPoints json field (#114)**
- **Bump golang.org/x/net from 0.37.0 to 0.38.0 (#111)**
- **Add note on how kubernetes-api is deployed (#113)**
- **Remove GetQdrantClusterCrdForHash helper (#116)**
- **Upate HelmRepository to v1 and HelmRelease to v2 (#115)**
- **Make `.spec.restartAllPodsConcurrently` a pointer to boolean (#123)**
- **Keep hashes unchanged: `.spec.restartAllPodsConcurrently` needs `omitempty` tag back (#125)**
- **Bump sigstore/cosign-installer from 3.8.1 to 3.8.2 (#121)**
- **Update version of tools, to fix documentation of enums (#127)**
- **Fix validation and docs for string enums (#126)**
- **Re-run make gen**
