### PR TITLE
Add `QdrantClusterRestore` `.spec.destination.create` field

### DIFF
--- a/api/v1/qdrantclusterrestore_types.go
+++ b/api/v1/qdrantclusterrestore_types.go
@@ -28,6 +28,12 @@ type RestoreDestination struct {
 	Name string `json:"name"`
 	// Namespace of the destination cluster
 	Namespace string `json:"namespace"`
+	// Create when set to true indicates that
+	// a new cluster with the specified name should be created.
+	// Otherwise, if set to false, the existing cluster is going to be restored
+	// to the specified state.
+	// +optional
+	Create bool `json:"create"`
 }
 
 type RestorePhase string

--- a/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantclusterrestores.yaml
+++ b/charts/qdrant-kubernetes-api/templates/region-crds/qdrant.io_qdrantclusterrestores.yaml
@@ -55,6 +55,13 @@ spec:
                 description: Destination defines the destination cluster where the
                   source data will end up
                 properties:
+                  create:
+                    description: |-
+                      Create when set to true indicates that
+                      a new cluster with the specified name should be created.
+                      Otherwise, if set to false, the existing cluster is going to be restored
+                      to the specified state.
+                    type: boolean
                   name:
                     description: Name of the destination cluster
                     type: string

--- a/crds/qdrant.io_qdrantclusterrestores.yaml
+++ b/crds/qdrant.io_qdrantclusterrestores.yaml
@@ -54,6 +54,13 @@ spec:
                 description: Destination defines the destination cluster where the
                   source data will end up
                 properties:
+                  create:
+                    description: |-
+                      Create when set to true indicates that
+                      a new cluster with the specified name should be created.
+                      Otherwise, if set to false, the existing cluster is going to be restored
+                      to the specified state.
+                    type: boolean
                   name:
                     description: Name of the destination cluster
                     type: string

--- a/docs/api.md
+++ b/docs/api.md
@@ -1197,6 +1197,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `name` _string_ | Name of the destination cluster |  |  |
 | `namespace` _string_ | Namespace of the destination cluster |  |  |
+| `create` _boolean_ | Create when set to true indicates that<br />a new cluster with the specified name should be created.<br />Otherwise, if set to false, the existing cluster is going to be restored<br />to the specified state. |  |  |
 
 
 #### RestorePhase


### PR DESCRIPTION
It makes new cluster creation explicit, preventing users to create
accidentally a cluster in case of typo in the referred cluster name.

Part of CRC-1133