### PR TITLE
feat(routing): add nil-safe getters to routing spec

### DIFF
--- a/api/routing/v1alpha1/routing_types.go
+++ b/api/routing/v1alpha1/routing_types.go
@@ -25,6 +25,16 @@ type QdrantClusterRouting struct {
 	Status QdrantClusterRoutingStatus `json:"status,omitempty"`
 }
 
+// GetSpec returns the routing spec, or the zero spec if the object is nil.
+// Returning a value (rather than a pointer) keeps the spec getters below usable
+// on the result, so callers can chain safely: qcrt.GetSpec().GetEnabled().
+func (r *QdrantClusterRouting) GetSpec() QdrantClusterRoutingSpec {
+	if r == nil {
+		return QdrantClusterRoutingSpec{}
+	}
+	return r.Spec
+}
+
 // QdrantClusterRoutingSpec describes the configuration for routing towards Qdrant clusters.
 type QdrantClusterRoutingSpec struct {
 	// ClusterId specifies the unique identifier of the cluster.
@@ -64,6 +74,83 @@ type QdrantClusterRoutingSpec struct {
 	// +kubebuilder:default=false
 	// +optional
 	MultiAZ bool `json:"multiAZ,omitempty"`
+}
+
+// GetClusterId returns the unique identifier of the cluster.
+func (s QdrantClusterRoutingSpec) GetClusterId() string {
+	return s.ClusterId
+}
+
+// GetFQDN returns the fully qualified domain name of the cluster.
+func (s QdrantClusterRoutingSpec) GetFQDN() string {
+	return s.FQDN
+}
+
+// GetEnabled returns whether ingress is enabled for the cluster.
+// Unset means enabled, matching the CRD default.
+func (s QdrantClusterRoutingSpec) GetEnabled() bool {
+	if s.Enabled == nil {
+		return true
+	}
+	return *s.Enabled
+}
+
+// GetShared returns whether the cluster uses at least one shared loadbalancer.
+func (s QdrantClusterRoutingSpec) GetShared() bool {
+	if s.Shared == nil {
+		return false
+	}
+	return *s.Shared
+}
+
+// GetDedicated returns whether the cluster uses at least one dedicated loadbalancer.
+func (s QdrantClusterRoutingSpec) GetDedicated() bool {
+	if s.Dedicated == nil {
+		return false
+	}
+	return *s.Dedicated
+}
+
+// GetTLS returns whether tls is enabled at qdrant level.
+func (s QdrantClusterRoutingSpec) GetTLS() bool {
+	if s.TLS == nil {
+		return false
+	}
+	return *s.TLS
+}
+
+// GetServicePerNode returns whether each node has a dedicated route.
+// Unset means enabled, matching the CRD default.
+func (s QdrantClusterRoutingSpec) GetServicePerNode() bool {
+	if s.ServicePerNode == nil {
+		return true
+	}
+	return *s.ServicePerNode
+}
+
+// GetNodeIndexes returns the indexes of the individual nodes in the cluster.
+func (s QdrantClusterRoutingSpec) GetNodeIndexes() []int {
+	return s.NodeIndexes
+}
+
+// GetAllowedSourceRanges returns the allowed CIDR source ranges for the ingress.
+// An empty result means no restriction, so callers that enforce it must treat
+// "no ranges" as "allow all" deliberately rather than by omission.
+func (s QdrantClusterRoutingSpec) GetAllowedSourceRanges() []string {
+	return s.AllowedSourceRanges
+}
+
+// GetEnableAccessLog returns whether the (proxy) access log is enabled.
+func (s QdrantClusterRoutingSpec) GetEnableAccessLog() bool {
+	if s.EnableAccessLog == nil {
+		return false
+	}
+	return *s.EnableAccessLog
+}
+
+// GetMultiAZ returns whether the cluster spans multiple availability zones.
+func (s QdrantClusterRoutingSpec) GetMultiAZ() bool {
+	return s.MultiAZ
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/api/routing/v1alpha1/routing_types_test.go
+++ b/api/routing/v1alpha1/routing_types_test.go
@@ -1,0 +1,96 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+)
+
+// TestQdrantClusterRoutingGetSpecIsNilSafe covers the entry point of the getter
+// chain: a nil object must read as the zero spec so callers can chain without a
+// nil check of their own.
+func TestQdrantClusterRoutingGetSpecIsNilSafe(t *testing.T) {
+	var qcrt *QdrantClusterRouting
+
+	assert.Equal(t, QdrantClusterRoutingSpec{}, qcrt.GetSpec())
+	// The whole point of the value return: this chain must not panic.
+	assert.Empty(t, qcrt.GetSpec().GetAllowedSourceRanges())
+	assert.Empty(t, qcrt.GetSpec().GetClusterId())
+	assert.Empty(t, qcrt.GetSpec().GetFQDN())
+	assert.False(t, qcrt.GetSpec().GetShared())
+	assert.False(t, qcrt.GetSpec().GetDedicated())
+	assert.False(t, qcrt.GetSpec().GetTLS())
+	assert.False(t, qcrt.GetSpec().GetEnableAccessLog())
+	assert.False(t, qcrt.GetSpec().GetMultiAZ())
+	assert.Empty(t, qcrt.GetSpec().GetNodeIndexes())
+}
+
+// TestQdrantClusterRoutingGetSpecReturnsSpec asserts GetSpec hands back the
+// actual spec, not a zero value, for a populated object.
+func TestQdrantClusterRoutingGetSpecReturnsSpec(t *testing.T) {
+	qcrt := &QdrantClusterRouting{
+		Spec: QdrantClusterRoutingSpec{
+			ClusterId:           "cluster-id",
+			FQDN:                "cluster-id.example.com",
+			AllowedSourceRanges: []string{"1.2.3.4/32"},
+		},
+	}
+
+	assert.Equal(t, "cluster-id", qcrt.GetSpec().GetClusterId())
+	assert.Equal(t, "cluster-id.example.com", qcrt.GetSpec().GetFQDN())
+	assert.Equal(t, []string{"1.2.3.4/32"}, qcrt.GetSpec().GetAllowedSourceRanges())
+}
+
+// TestQdrantClusterRoutingSpecDefaults pins the unset behaviour of every
+// optional field. Enabled and ServicePerNode default to true to match their
+// +kubebuilder:default markers, so an unset pointer must NOT read as false the
+// way a plain dereference helper would report it.
+func TestQdrantClusterRoutingSpecDefaults(t *testing.T) {
+	var spec QdrantClusterRoutingSpec
+
+	assert.True(t, spec.GetEnabled(), "unset Enabled defaults to true (CRD default)")
+	assert.True(t, spec.GetServicePerNode(), "unset ServicePerNode defaults to true (CRD default)")
+
+	assert.False(t, spec.GetShared())
+	assert.False(t, spec.GetDedicated())
+	assert.False(t, spec.GetTLS())
+	assert.False(t, spec.GetEnableAccessLog())
+	assert.False(t, spec.GetMultiAZ())
+
+	assert.Empty(t, spec.GetClusterId())
+	assert.Empty(t, spec.GetFQDN())
+	assert.Empty(t, spec.GetNodeIndexes())
+	assert.Empty(t, spec.GetAllowedSourceRanges())
+}
+
+// TestQdrantClusterRoutingSpecGetters asserts every getter reports the value it
+// was given, including the false-but-set case that the default-aware getters
+// must not override.
+func TestQdrantClusterRoutingSpecGetters(t *testing.T) {
+	spec := QdrantClusterRoutingSpec{
+		ClusterId:           "cluster-id",
+		FQDN:                "cluster-id.example.com",
+		Enabled:             ptr.To(false),
+		Shared:              ptr.To(true),
+		Dedicated:           ptr.To(true),
+		TLS:                 ptr.To(true),
+		ServicePerNode:      ptr.To(false),
+		NodeIndexes:         []int{0, 1, 2},
+		AllowedSourceRanges: []string{"1.2.3.4/32", "10.0.0.0/8"},
+		EnableAccessLog:     ptr.To(true),
+		MultiAZ:             true,
+	}
+
+	assert.Equal(t, "cluster-id", spec.GetClusterId())
+	assert.Equal(t, "cluster-id.example.com", spec.GetFQDN())
+	assert.False(t, spec.GetEnabled(), "an explicit false must win over the default")
+	assert.True(t, spec.GetShared())
+	assert.True(t, spec.GetDedicated())
+	assert.True(t, spec.GetTLS())
+	assert.False(t, spec.GetServicePerNode(), "an explicit false must win over the default")
+	assert.Equal(t, []int{0, 1, 2}, spec.GetNodeIndexes())
+	assert.Equal(t, []string{"1.2.3.4/32", "10.0.0.0/8"}, spec.GetAllowedSourceRanges())
+	assert.True(t, spec.GetEnableAccessLog())
+	assert.True(t, spec.GetMultiAZ())
+}


### PR DESCRIPTION
## Why

The routing types had **no getters at all** — the whole package contained only `init()`. Callers reach into `QdrantClusterRouting.Spec` directly, so every hop is a potential nil dereference and every optional pointer field gets dereferenced ad hoc at the call site.

Enforcing `allowedSourceRanges` in route-manager made that concrete (qdrant/qdrant-cloud-route-manager#280): a route whose spec is missing must read as "no ranges known" at the call site, rather than panicking inside listener construction — which would take down the Envoy snapshot for every other tenant sharing that config, not just the one bad route.

This brings the routing types in line with `api/v1`, which already has 39 hand-written getters.

## What

`GetSpec()` on `QdrantClusterRouting`, plus a getter per field on `QdrantClusterRoutingSpec`.

Two deliberate design choices:

**`GetSpec()` returns a value, not a pointer.** `Spec` is a value field, and the spec getters use value receivers (matching `QdrantClusterSpec.GetServicePerNode()`). A function result isn't addressable, so a pointer-receiver getter could not be called on it — a value return is what makes the chain compile:

```go
qcrt.GetSpec().GetAllowedSourceRanges()   // nil-safe end to end
```

**Defaulted fields honour their CRD default.** `Enabled` and `ServicePerNode` both carry `+kubebuilder:default=true`, so their getters report `true` when unset — the value the API server would have persisted. Everything else reports `false`/empty when unset.

⚠️ This means `GetEnabled()` and `refs.DerefPointer(Spec.Enabled)` are **not** interchangeable: the latter reports `false` for an unset pointer. Anyone migrating existing call sites should check which semantic they actually want. The doc comments and tests both call this out.

## Notes

- Purely additive: new methods only, no field, type, or CRD change. Nothing that exists today changes behaviour.
- Getters are hand-written here by convention, not generated — `make gen` only produces CRD manifests, deepcopy methods, and `docs/api.md`, and there are zero `Get*` methods in any `zz_generated.deepcopy.go`.
- `make gen` produces no drift, so the "make gen did not result in changes" gate passes.

## Tests

New `routing_types_test.go`:

- `TestQdrantClusterRoutingGetSpecIsNilSafe` — a nil object chains through every getter without panicking.
- `TestQdrantClusterRoutingGetSpecReturnsSpec` — a populated object returns its real spec, not a zero value.
- `TestQdrantClusterRoutingSpecDefaults` — pins the unset behaviour of all 11 fields, including the two that default to `true`.
- `TestQdrantClusterRoutingSpecGetters` — every getter reports what it was given, including explicit `false` on the defaulted fields (the default must not override a set value).

## Follow-up

Once released, route-manager can adopt the chain in place of its local `RoutingInfo.GetAllowedSourceRanges()` helper, and the direct `ri.QCR.Spec.*` accesses elsewhere in that package can migrate too. Not a blocker for the security fix in #280, which ships on the local helper and needs no dependency bump.
